### PR TITLE
OpenAI.recipe.md: Fix parameter name

### DIFF
--- a/OpenAI.recipe.md
+++ b/OpenAI.recipe.md
@@ -137,7 +137,7 @@ Modify: `conf/opensm/opensm.conf`
 #Amount of physical port to handle in one shot
 virt_max_ports_in_process 512
 
-max_operational_vls 2
+max_op_vls 2
 
 qos TRUE
 


### PR DESCRIPTION
 max_operational_vls->max_op_vls

Signed-off-by: Sasha Kotchubievsky <sashakot@users.noreply.github.com>