### PR TITLE
OpenAI.recipe.md: Increase ibdiagnet timeout

### DIFF
--- a/OpenAI.recipe.md
+++ b/OpenAI.recipe.md
@@ -79,7 +79,7 @@ unmanaged_switches_interval = -1
 periodic_discovery_interval = 30
 
 # timeout for ibdiagnet run time (in seconds)
-ibdiagnet_timeout = 600
+ibdiagnet_timeout = 3600
 
 
 [Sharp]


### PR DESCRIPTION
 Depends on parameters, ibdiagnet run can take time.
 UMF kills ibdiagnet when ibdiagnet_timeout is expired

Signed-off-by: Sasha Kotchubievsky <sashakot@users.noreply.github.com>